### PR TITLE
Move label tokens from foundations to component

### DIFF
--- a/src/Label/Tokens/tokens.ts
+++ b/src/Label/Tokens/tokens.ts
@@ -1,0 +1,14 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  content: {
+    color: {
+      regular: inube.palette.neutral.N900,
+      disabled: inube.palette.neutral.N70,
+      focus: inube.palette.blue.B300,
+      invalid: inube.palette.red.R400,
+    },
+  },
+};
+
+export { tokens };

--- a/src/Label/styles.js
+++ b/src/Label/styles.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledLabel = styled.label`
   font-family: ${({ theme, $size }) =>
@@ -14,26 +15,22 @@ const StyledLabel = styled.label`
   color: ${({ theme, $disabled, $focused, $invalid }) => {
     if ($disabled) {
       return (
-        theme?.label?.content?.color?.disabled ||
-        inube.label.content.color.disabled
+        theme?.label?.content?.color?.disabled || tokens.content.color.disabled
       );
     }
 
     if ($invalid) {
       return (
-        theme?.label?.content?.color?.invalid ||
-        inube.label.content.color.invalid
+        theme?.label?.content?.color?.invalid || tokens.content.color.invalid
       );
     }
 
     if ($focused) {
-      return (
-        theme?.label?.content?.color?.focus || inube.label.content.color.focus
-      );
+      return theme?.label?.content?.color?.focus || tokens.content.color.focus;
     }
 
     return (
-      theme?.label?.content?.color?.regular || inube.label.content.color.regular
+      theme?.label?.content?.color?.regular || tokens.content.color.regular
     );
   }};
 `;


### PR DESCRIPTION
This PR relocates the label tokens from the foundations folder to the component folder, updating all necessary imports to align with the new structure and ensuring that components reference the correct token paths. This update improves the organization, maintainability, and clarity of the codebase.